### PR TITLE
Update POM to add GPG arguments

### DIFF
--- a/test-automation-framework/pom.xml
+++ b/test-automation-framework/pom.xml
@@ -121,6 +121,13 @@
 						<goals>
 							<goal>sign</goal>
 						</goals>
+						<configuration>
+                                    		<!-- Prevent gpg from using pinentry programs. Fixes: gpg: signing failed: Inappropriate ioctl for device -->
+                                   			<gpgArguments>
+                                        			<arg>--pinentry-mode</arg>
+                                        			<arg>loopback</arg>
+                                    			</gpgArguments>
+                                		</configuration>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
pinentry-mode=loopback is necessary to avoid GPG prompting manual entry of the GPG passphrase