### PR TITLE
V 1.0.3 - Fix for Saucelabs screenResolution Issue #55

### DIFF
--- a/orange-hrm/pom.xml
+++ b/orange-hrm/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>io.github.innovativeqalab</groupId>
 			<artifactId>test-automation-framework</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.3</version>
 		</dependency>
 	</dependencies>
 

--- a/orange-hrm/src/test/resources/properties/capabilities/BrowserCapabilities.properties
+++ b/orange-hrm/src/test/resources/properties/capabilities/BrowserCapabilities.properties
@@ -1,11 +1,20 @@
 #---------------------------------------------------------
 #      Browser Capabilities
 #---------------------------------------------------------
-#platform=WIN10
+
+# Remote Execution (If Driver = REMOTE)
+#---------------------------------------------------------
 browserName=chrome
-version=latest
-#for sauce lab resolution
+#platform=Windows 10
+#version=latest
+
+#Below capability can be used for Saucelabs execution
+#---------------------------------------------------------
 #screenResolution=1680x1050
+
+#https://docs.saucelabs.com/dev/w3c-webdriver-capabilities/
+
+
 ## READ ME
 # Capabilities Precedence will be given to ENVIRONMENT > PARAMETER > PROPERTIES is passed
 # ENVIRONMENT variable can be set via CI tool 

--- a/orange-hrm/src/test/resources/properties/capabilities/BrowserCapabilities.properties
+++ b/orange-hrm/src/test/resources/properties/capabilities/BrowserCapabilities.properties
@@ -1,10 +1,11 @@
 #---------------------------------------------------------
 #      Browser Capabilities
 #---------------------------------------------------------
+#platform=WIN10
 browserName=chrome
-version=103
+version=latest
 #for sauce lab resolution
-screenResolution=1680x1050
+#screenResolution=1680x1050
 ## READ ME
 # Capabilities Precedence will be given to ENVIRONMENT > PARAMETER > PROPERTIES is passed
 # ENVIRONMENT variable can be set via CI tool 

--- a/orange-hrm/src/test/resources/properties/framework/FrameworkConfig.properties
+++ b/orange-hrm/src/test/resources/properties/framework/FrameworkConfig.properties
@@ -12,8 +12,8 @@ AUT=WEB
 #---------------------------------------------------------
 #DRIVER=REMOTE or BROWSER (For REMOTE mode HUB_URL is mandatory and grid/slave setup should be done)
 DRIVER=BROWSER
-#platform=WINDOWS OR LINUX or ANDROID or IOS
-platform=WINDOWS
+#platformOS=WINDOWS OR LINUX or ANDROID or IOS
+platformOS=WINDOWS
 
 #---------- If Driver = BROWSER Then
 browser=chrome

--- a/orange-hrm/src/test/resources/properties/framework/FrameworkConfig.properties
+++ b/orange-hrm/src/test/resources/properties/framework/FrameworkConfig.properties
@@ -1,31 +1,46 @@
 #---------------------------------------------------------
 #      AUT [Application Under Test] Configurations
 #---------------------------------------------------------
-#AUT should have values from => [ WEB/MOBILE/API_ONLY]
+#AUT should have values from => [ WEB/ANDROID/IOS/API_ONLY]
 #WEB : This can be configured for WEB Automation [Along with API Automation if needed].
-#MOBILE : This can be configured for MOBILE Automation [Along with API Automation if needed].
+#ANDROID/IOS : This can be configured for MOBILE Automation [Along with API Automation if needed].
 #API_ONLY : This can be configured for API Automation only.
 AUT=WEB
 
 #---------------------------------------------------------
 #      WebDriver/AppiumDriver Configurations
 #---------------------------------------------------------
-#DRIVER=REMOTE or BROWSER (For REMOTE mode HUB_URL is mandatory and grid/slave setup should be done)
-DRIVER=BROWSER
-#platformOS=WINDOWS OR LINUX or ANDROID or IOS
-platformOS=WINDOWS
-
-#---------- If Driver = BROWSER Then
-browser=chrome
-browserVersion=105
-DRIVER_EXECUTABLE_PATH=/Users/prashantbhange/Documents/Selenium/chromedriver
-DRIVER_PROPERTY_NAME=webdriver.chrome.driver
-#--------- If DRIVER=REMOTE Then  //This can be Grid/Hub URL or Appium URL
-#--------- Capabilities for RemoteWebDriver must set in respective property files in src/test/resources/CapabilityProperties folder
-#hubUrl=https://sso-fdc-qa-vaibhav.zodge:***@ondemand.us-west-1.saucelabs.com:443/wd/hub
-hubUrl=http://selenium:4444/wd/hub
+#DRIVER should have values from => [REMOTE/BROWSER]
+#REMOTE : This can be configured for Remote execution where huburl is mandatory and grid/slave set should be done before execution
+#BROWSER : This can be configured for Local execution where browser details and configurations are mandatory
+DRIVER=REMOTE
 #---------------------------------------------------------
-#                 READ ME
+# Local Execution (If DRIVER = BROWSER)
+#--------------------------------------------------------- 
+# browser [chrome/ie/firefox etc]
+browser=chrome
+#Please provide here respective browser driver executable path
+DRIVER_EXECUTABLE_PATH=/Users/********/Documents/Selenium/chromedriver
+DRIVER_PROPERTY_NAME=webdriver.chrome.driver
+
+#---------------------------------------------------------
+# Remote Execution (If DRIVER = REMOTE)
+#--------------------------------------------------------- 
+#For REMOTE mode hubUrl is mandatory and grid/slave set up should be done
+#Below can be Grid/Hub URL or Saucelabs URL or Appium URL
+#hubUrl=https://sso-fdc-qa-***.***:***@ondemand.*.saucelabs.com:443/wd/hub
+hubUrl=http://localhost:4444/wd/hub
+
+#---------------------------------------------------------
+#                 READ ME - Capabilities
+#---------------------------------------------------------
+# Please set Desired capabilities in respective property files in src/test/resources/properties/capabilities folder
+# Browser - BrowserCapabilities.properties
+# Android - AndroidCapabilities.properties
+# iOS 	  - iOSCapabilities.properties
+
+#---------------------------------------------------------
+#                 READ ME - Properties Precedence
 #---------------------------------------------------------
 # Precedence will be given to ENVIRONMENT > PARAMETER > PROPERTIES
 # ENVIRONMENT variable can be set via CI tool 

--- a/test-automation-framework/pom.xml
+++ b/test-automation-framework/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.github.innovativeqalab</groupId>
 	<artifactId>test-automation-framework</artifactId>
-	<version>1.0.2</version>
+	<version>1.0.3</version>
 	<packaging>jar</packaging>
 	<name>test-automation-framework</name>
 	<description>Functional Test Automation Framework</description>

--- a/test-automation-framework/src/main/java/org/iqa/suite/commons/SeleniumUtils.java
+++ b/test-automation-framework/src/main/java/org/iqa/suite/commons/SeleniumUtils.java
@@ -2,7 +2,6 @@ package org.iqa.suite.commons;
 
 import java.io.File;
 import java.io.IOException;
-
 import org.apache.commons.io.FileUtils;
 import org.iqa.test.webdriver_factory.WebDriverFactory;
 import org.openqa.selenium.OutputType;
@@ -11,14 +10,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SeleniumUtils {
-    private static final Logger logger = LoggerFactory.getLogger(SeleniumUtils.class);
+	private static final Logger logger = LoggerFactory.getLogger(SeleniumUtils.class);
 
 	public static void takeScreenshot(String fileNameWithPath) {
 		if (null == WebDriverFactory.getDriver()) {
 			logger.info("!!!!!! Webdriver is null hence returning from SeleniumUtil > takeScreenShot()");
 			return;
 		}
-		logger.info("********** Taking screenshot at - "+fileNameWithPath);
+		logger.info("********** Taking screenshot at - " + fileNameWithPath);
 		File scrFile = ((TakesScreenshot) WebDriverFactory.getDriver()).getScreenshotAs(OutputType.FILE);
 		try {
 			FileUtils.copyFile(scrFile, new File(fileNameWithPath));
@@ -27,14 +26,39 @@ public class SeleniumUtils {
 			e.printStackTrace();
 		}
 	}
-	
+
 	public static String getScreenshotAsBase64() {
 		if (null == WebDriverFactory.getDriver()) {
 			logger.info("!!!!!! Webdriver is null hence returning from SeleniumUtil > takeScreenShot()");
 			return null;
 		}
 		logger.info("********** Taking screenshot as Base64 ");
-		return  ((TakesScreenshot) WebDriverFactory.getDriver()).getScreenshotAs(OutputType.BASE64);	
+		return ((TakesScreenshot) WebDriverFactory.getDriver()).getScreenshotAs(OutputType.BASE64);
 	}
+
+	/**
+	 * Returns OS Family name based on platform name
+	 *
+	 * @param platformProperty/*
+	 * @return String osFamilyName
+	 */
+	public static String getOsFamilyName(String platformProperty) {
+		String platform = platformProperty.toLowerCase();
+		if (platform.contains("windows") || platform.contains("win")) {
+			return "WINDOWS";
+		} else if (platform.contains("linux")) {
+			return "LINUX";
+		} else if (platform.contains("mac")) {
+			return "MAC";
+		} else if (platform.contains("ios")) {
+			return "IOS";
+		} else if (platform.contains("android")) {
+			return "ANDROID";
+		} else {
+			throw new IllegalArgumentException(
+					"!!! Platform property " + platformProperty + " is not currently supported with this version of framework!!!");
+		}
+	}
+	
 
 }

--- a/test-automation-framework/src/main/java/org/iqa/suite/commons/applitool/ApplitoolEyesWeb.java
+++ b/test-automation-framework/src/main/java/org/iqa/suite/commons/applitool/ApplitoolEyesWeb.java
@@ -44,7 +44,7 @@ public class ApplitoolEyesWeb {
 		config.setApiKey(applitoolApiKey);
 		config.setBatch(
 				new BatchInfo(PropertyHolder.testSuiteConfigurationProperties.getProperty("BATCH_NAME").toString()));
-		config.setHostOS(PropertyHolder.testSuiteConfigurationProperties.getProperty("platform").toString());
+		config.setHostOS(PropertyHolder.testSuiteConfigurationProperties.getProperty("platformOS").toString());
 	}
 
 	public static EyesRunner getApplitoolEyeRunner() {

--- a/test-automation-framework/src/main/java/org/iqa/suite/commons/applitool/ApplitoolEyesWeb.java
+++ b/test-automation-framework/src/main/java/org/iqa/suite/commons/applitool/ApplitoolEyesWeb.java
@@ -44,7 +44,7 @@ public class ApplitoolEyesWeb {
 		config.setApiKey(applitoolApiKey);
 		config.setBatch(
 				new BatchInfo(PropertyHolder.testSuiteConfigurationProperties.getProperty("BATCH_NAME").toString()));
-		config.setHostOS(PropertyHolder.testSuiteConfigurationProperties.getProperty("platformOS").toString());
+		//config.setHostOS(PropertyHolder.testSuiteConfigurationProperties.getProperty("platform").toString());
 	}
 
 	public static EyesRunner getApplitoolEyeRunner() {

--- a/test-automation-framework/src/main/java/org/iqa/suite/commons/applitool/ApplitoolsEyesUtils.java
+++ b/test-automation-framework/src/main/java/org/iqa/suite/commons/applitool/ApplitoolsEyesUtils.java
@@ -1,4 +1,5 @@
 package org.iqa.suite.commons.applitool;
+
 import org.iqa.suite.commons.PropertyHolder;
 import org.iqa.suite.commons.TestMetaData;
 import org.iqa.test.webdriver_factory.WebDriverFactory;
@@ -10,28 +11,26 @@ import com.applitools.eyes.TestResultsSummary;
 public class ApplitoolsEyesUtils {
 
 	private static final Logger logger = LoggerFactory.getLogger(ApplitoolsEyesUtils.class);
-	private static String platform = null;
+	private static String platformOS = null;
 	private static String EYE_ENABLE = null;
 	private static String APPLITOOLS_API_KEY = null;
 
 	static {
-
 		logger.debug("********* In ApplitoolsEyesUtils static block...");
-		platform = PropertyHolder.testSuiteConfigurationProperties.getProperty("platform").toString();
+		platformOS = PropertyHolder.testSuiteConfigurationProperties.getProperty("platformOS").toString();
 		EYE_ENABLE = PropertyHolder.testSuiteConfigurationProperties.getProperty("EYE_ENABLE").toString();
 		APPLITOOLS_API_KEY = PropertyHolder.testSuiteConfigurationProperties.getProperty("APPLITOOLS_API_KEY")
 				.toString();
 	}
 
 	public static void setApplitoolEyeConfig() {
-
 		if (null != EYE_ENABLE && new Boolean(EYE_ENABLE) == true) {
-			if (platform.equalsIgnoreCase("LINUX") || platform.equalsIgnoreCase("WINDOWS")) {
+			if (platformOS.equalsIgnoreCase("LINUX") || platformOS.equalsIgnoreCase("WINDOWS")) {
 				logger.info("********* Opening Applitool Eyes for Web");
 				ApplitoolEyesWeb.enabled = true;
 				ApplitoolEyesWeb.setApplitoolCongfig(APPLITOOLS_API_KEY);
 				logger.info("Applitools eyes configuration setup done.");
-			} else if (platform.equalsIgnoreCase("ANDROID") || platform.equalsIgnoreCase("IOS")) {
+			} else if (platformOS.equalsIgnoreCase("ANDROID") || platformOS.equalsIgnoreCase("IOS")) {
 				logger.info("********* Opening Applitool Eyes for Mobile");
 				ApplitoolEyesMobile.enabled = true;
 				ApplitoolEyesMobile.setApplitoolCongfig(APPLITOOLS_API_KEY);
@@ -40,28 +39,29 @@ public class ApplitoolsEyesUtils {
 				logger.info("!!!!!!!!!!!!! Platform not found, it must be within {Android,IOS,LINUX,WINDOWS}");
 				System.exit(1);
 			}
-
 		}
 	}
 
 	public static void openApplitoolEye() {
 		if ((ApplitoolEyesWeb.enabled == true || ApplitoolEyesMobile.enabled) == true) {
-			if (platform.equalsIgnoreCase("LINUX") || platform.equalsIgnoreCase("WINDOWS")) {
-				ApplitoolEyesWeb.createEyes().open(WebDriverFactory.getDriver(), TestMetaData.getFeatureWrapper().toString(),
-						TestMetaData.getPickleWrapper().toString() + ":" + PropertyHolder.testSuiteConfigurationProperties
-								.getProperty("platform").toLowerCase());// ,new RectangleSize(1024, 751));
+			if (platformOS.equalsIgnoreCase("LINUX") || platformOS.equalsIgnoreCase("WINDOWS")) {
+				ApplitoolEyesWeb.createEyes().open(WebDriverFactory.getDriver(),
+						TestMetaData.getFeatureWrapper().toString(),
+						TestMetaData.getPickleWrapper().toString() + ":"
+								+ PropertyHolder.testSuiteConfigurationProperties.getProperty("platformOS")
+										.toLowerCase());// ,new RectangleSize(1024, 751));
 
-			} else if (platform.equalsIgnoreCase("ANDROID") || platform.equalsIgnoreCase("IOS")) {
-				ApplitoolEyesMobile.createEyes().open(WebDriverFactory.getDriver(), TestMetaData.getFeatureWrapper().toString(),
-						TestMetaData.getPickleWrapper().toString() + ":" + PropertyHolder.testSuiteConfigurationProperties
-								.getProperty("platform").toLowerCase());// ,new RectangleSize(1024, 751));
+			} else if (platformOS.equalsIgnoreCase("ANDROID") || platformOS.equalsIgnoreCase("IOS")) {
+				ApplitoolEyesMobile.createEyes().open(WebDriverFactory.getDriver(),
+						TestMetaData.getFeatureWrapper().toString(),
+						TestMetaData.getPickleWrapper().toString() + ":"
+								+ PropertyHolder.testSuiteConfigurationProperties.getProperty("platformOS")
+										.toLowerCase());// ,new RectangleSize(1024, 751));
 			}
 		}
-
 	}
 
 	public static void closeApplitoolEye() {
-
 		logger.info("****** Closing Applitools Eyes...");
 		if (ApplitoolEyesWeb.enabled == true && null != ApplitoolEyesWeb.getEyes()
 				&& ApplitoolEyesWeb.getEyes().getIsOpen()) {

--- a/test-automation-framework/src/main/java/org/iqa/suite/commons/applitool/ApplitoolsEyesUtils.java
+++ b/test-automation-framework/src/main/java/org/iqa/suite/commons/applitool/ApplitoolsEyesUtils.java
@@ -1,6 +1,7 @@
 package org.iqa.suite.commons.applitool;
 
 import org.iqa.suite.commons.PropertyHolder;
+import org.iqa.suite.commons.SeleniumUtils;
 import org.iqa.suite.commons.TestMetaData;
 import org.iqa.test.webdriver_factory.WebDriverFactory;
 import org.slf4j.Logger;
@@ -11,13 +12,13 @@ import com.applitools.eyes.TestResultsSummary;
 public class ApplitoolsEyesUtils {
 
 	private static final Logger logger = LoggerFactory.getLogger(ApplitoolsEyesUtils.class);
-	private static String platformOS = null;
+	private static String AUT = null;
 	private static String EYE_ENABLE = null;
 	private static String APPLITOOLS_API_KEY = null;
 
 	static {
 		logger.debug("********* In ApplitoolsEyesUtils static block...");
-		platformOS = PropertyHolder.testSuiteConfigurationProperties.getProperty("platformOS").toString();
+		AUT = PropertyHolder.testSuiteConfigurationProperties.getProperty("AUT").toString();
 		EYE_ENABLE = PropertyHolder.testSuiteConfigurationProperties.getProperty("EYE_ENABLE").toString();
 		APPLITOOLS_API_KEY = PropertyHolder.testSuiteConfigurationProperties.getProperty("APPLITOOLS_API_KEY")
 				.toString();
@@ -25,18 +26,18 @@ public class ApplitoolsEyesUtils {
 
 	public static void setApplitoolEyeConfig() {
 		if (null != EYE_ENABLE && new Boolean(EYE_ENABLE) == true) {
-			if (platformOS.equalsIgnoreCase("LINUX") || platformOS.equalsIgnoreCase("WINDOWS")) {
+			if (AUT.equalsIgnoreCase("WEB")) {
 				logger.info("********* Opening Applitool Eyes for Web");
 				ApplitoolEyesWeb.enabled = true;
 				ApplitoolEyesWeb.setApplitoolCongfig(APPLITOOLS_API_KEY);
 				logger.info("Applitools eyes configuration setup done.");
-			} else if (platformOS.equalsIgnoreCase("ANDROID") || platformOS.equalsIgnoreCase("IOS")) {
+			} else if (AUT.equalsIgnoreCase("ANDROID") || AUT.equalsIgnoreCase("IOS")) {
 				logger.info("********* Opening Applitool Eyes for Mobile");
 				ApplitoolEyesMobile.enabled = true;
 				ApplitoolEyesMobile.setApplitoolCongfig(APPLITOOLS_API_KEY);
 				logger.info("********* Applitool configuration setup done.");
 			} else {
-				logger.info("!!!!!!!!!!!!! Platform not found, it must be within {Android,IOS,LINUX,WINDOWS}");
+				logger.info("!!!!!!!!!!!!! Invalid AUT property value. Please provide correct value from {WEB,ANDROID,IOS}");
 				System.exit(1);
 			}
 		}
@@ -44,19 +45,18 @@ public class ApplitoolsEyesUtils {
 
 	public static void openApplitoolEye() {
 		if ((ApplitoolEyesWeb.enabled == true || ApplitoolEyesMobile.enabled) == true) {
-			if (platformOS.equalsIgnoreCase("LINUX") || platformOS.equalsIgnoreCase("WINDOWS")) {
+			String platform = SeleniumUtils.getOsFamilyName(PropertyHolder.testSuiteConfigurationProperties.getProperty("platform").toString());
+			if (platform.equalsIgnoreCase("LINUX") || platform.equalsIgnoreCase("WINDOWS")) {
 				ApplitoolEyesWeb.createEyes().open(WebDriverFactory.getDriver(),
 						TestMetaData.getFeatureWrapper().toString(),
 						TestMetaData.getPickleWrapper().toString() + ":"
-								+ PropertyHolder.testSuiteConfigurationProperties.getProperty("platformOS")
-										.toLowerCase());// ,new RectangleSize(1024, 751));
+								+ platform.toLowerCase());// ,new RectangleSize(1024, 751));
 
-			} else if (platformOS.equalsIgnoreCase("ANDROID") || platformOS.equalsIgnoreCase("IOS")) {
+			} else if (platform.equalsIgnoreCase("ANDROID") || platform.equalsIgnoreCase("IOS")) {
 				ApplitoolEyesMobile.createEyes().open(WebDriverFactory.getDriver(),
 						TestMetaData.getFeatureWrapper().toString(),
 						TestMetaData.getPickleWrapper().toString() + ":"
-								+ PropertyHolder.testSuiteConfigurationProperties.getProperty("platformOS")
-										.toLowerCase());// ,new RectangleSize(1024, 751));
+								+ platform.toLowerCase());// ,new RectangleSize(1024, 751));
 			}
 		}
 	}

--- a/test-automation-framework/src/main/java/org/iqa/suite/commons/applitool/ApplitoolsEyesUtils.java
+++ b/test-automation-framework/src/main/java/org/iqa/suite/commons/applitool/ApplitoolsEyesUtils.java
@@ -46,7 +46,7 @@ public class ApplitoolsEyesUtils {
 	public static void openApplitoolEye() {
 		if ((ApplitoolEyesWeb.enabled == true || ApplitoolEyesMobile.enabled) == true) {
 			String platform = SeleniumUtils.getOsFamilyName(PropertyHolder.testSuiteConfigurationProperties.getProperty("platform").toString());
-			if (platform.equalsIgnoreCase("LINUX") || platform.equalsIgnoreCase("WINDOWS")) {
+			if (platform.equalsIgnoreCase("LINUX") || platform.equalsIgnoreCase("WINDOWS") || platform.equalsIgnoreCase("MAC")) {
 				ApplitoolEyesWeb.createEyes().open(WebDriverFactory.getDriver(),
 						TestMetaData.getFeatureWrapper().toString(),
 						TestMetaData.getPickleWrapper().toString() + ":"

--- a/test-automation-framework/src/main/java/org/iqa/suite/commons/listeners/TestNGMethodInvocationListener.java
+++ b/test-automation-framework/src/main/java/org/iqa/suite/commons/listeners/TestNGMethodInvocationListener.java
@@ -41,12 +41,12 @@ public class TestNGMethodInvocationListener implements IInvokedMethodListener {
 					WebDriverFactory.getDriver().manage().window().maximize();
 					logger.info("******** Driver object and test report instance created successfully");
 				} catch (MalformedURLException e) {
-					logger.error("!!!!!!!! Exception while creating Driver object and test report instance ");
 					logger.error("!!!!!!!! Exception occured while creating Driver object and test report instance ");
 					e.printStackTrace();
 				}
 				break;
-			case "MOBILE":
+			case "ANDROID":
+			case "IOS":
 				try {
 					WebDriverFactory.setDriver(WebDriverManager.CreateInstance());
 				} catch (MalformedURLException e) {
@@ -59,7 +59,7 @@ public class TestNGMethodInvocationListener implements IInvokedMethodListener {
 				break;
 
 			default:
-				logger.error("!!!!!!!! AUT property should have values from [WEB/MOBILE/API_ONLY]. Exiting...");
+				logger.error("!!!!!!!! AUT property should have values from [WEB/ANDROID/IOS/API_ONLY]. Exiting...");
 				break;
 			}
 			softAssert = new SoftAssert();

--- a/test-automation-framework/src/main/java/org/iqa/test/base/BaseTest.java
+++ b/test-automation-framework/src/main/java/org/iqa/test/base/BaseTest.java
@@ -59,15 +59,17 @@ public class BaseTest extends AbstractTestNGCucumberTests {
 
 	@AfterSuite
 	public void afterSuite() {
-		if (null != AUT && !AUT.equalsIgnoreCase("API_ONLY")) {
-			if (null != PropertyHolder.testSuiteConfigurationProperties.getProperty("EYE_ENABLE") && new Boolean(
-					PropertyHolder.testSuiteConfigurationProperties.getProperty("EYE_ENABLE").toString()) == true) {
-				String platform = SeleniumUtils.getOsFamilyName(PropertyHolder.testSuiteConfigurationProperties.getProperty("platform").toString());
-				if (platform.equalsIgnoreCase("LINUX")) {
-					ApplitoolsEyesUtils.applicationToolEyeWebGetAllTestResults(); // Only for Web
-				}
-			}
-		}
+//    ***** Skipping applicationToolEyeWebGetAllTestResults as it is taking longer time for processing and causing execution pipeline to wait
+//
+//		if (null != AUT && !AUT.equalsIgnoreCase("API_ONLY")) {
+//			if (null != PropertyHolder.testSuiteConfigurationProperties.getProperty("EYE_ENABLE") && new Boolean(
+//					PropertyHolder.testSuiteConfigurationProperties.getProperty("EYE_ENABLE").toString()) == true) {
+//				String platform = SeleniumUtils.getOsFamilyName(PropertyHolder.testSuiteConfigurationProperties.getProperty("platform").toString());
+//				if (platform.equalsIgnoreCase("LINUX")) {
+//					ApplitoolsEyesUtils.applicationToolEyeWebGetAllTestResults(); // Only for Web
+//				}
+//			}
+//		}
 
 	}
 }

--- a/test-automation-framework/src/main/java/org/iqa/test/base/BaseTest.java
+++ b/test-automation-framework/src/main/java/org/iqa/test/base/BaseTest.java
@@ -1,6 +1,7 @@
 package org.iqa.test.base;
 
 import org.iqa.suite.commons.PropertyHolder;
+import org.iqa.suite.commons.SeleniumUtils;
 import org.iqa.suite.commons.TestMetaData;
 import org.iqa.suite.commons.applitool.ApplitoolsEyesUtils;
 import org.iqa.suite.commons.listeners.TestNGMethodInvocationListener;
@@ -34,8 +35,8 @@ public class BaseTest extends AbstractTestNGCucumberTests {
 		if (null == AUT) {
 			logger.error(
 					"!!!!!!!!!! AUT Property must be set in src/test/resources/properties/framework/FrameworkConfig.properties"
-							+ "\n Property name should be AUT and values should be one of {WEB, MOBILE, API_ONLY.}"
-							+ "\n AUT should be set as WEB and MOBILE if you want to execute Web/Mobile automation tests and it also allows execution of API tests."
+							+ "\n Property name should be AUT and values should be one of {WEB, ANDROID,IOS, API_ONLY.}"
+							+ "\n AUT should be set as WEB/ANDROID/IOS if you want to execute Web/Mobile automation tests and it also allows execution of API tests."
 							+ "\n AUT should be set as API_ONLY if you want to execute only API tests}. Exiting...");
 			System.exit(-1);
 		}
@@ -43,6 +44,7 @@ public class BaseTest extends AbstractTestNGCucumberTests {
 		if (!AUT.equalsIgnoreCase("API_ONLY")) {
 			logger.info("********* Setting applitool eyes configs...");
 			ApplitoolsEyesUtils.setApplitoolEyeConfig();
+			logger.info("********* Applitools eyes configs set up done.");
 
 		}
 	}
@@ -60,23 +62,12 @@ public class BaseTest extends AbstractTestNGCucumberTests {
 		if (null != AUT && !AUT.equalsIgnoreCase("API_ONLY")) {
 			if (null != PropertyHolder.testSuiteConfigurationProperties.getProperty("EYE_ENABLE") && new Boolean(
 					PropertyHolder.testSuiteConfigurationProperties.getProperty("EYE_ENABLE").toString()) == true) {
-				if (PropertyHolder.testSuiteConfigurationProperties.getProperty("platform").toString()
-						.equalsIgnoreCase("LINUX")) {
+				String platform = SeleniumUtils.getOsFamilyName(PropertyHolder.testSuiteConfigurationProperties.getProperty("platform").toString());
+				if (platform.equalsIgnoreCase("LINUX")) {
 					ApplitoolsEyesUtils.applicationToolEyeWebGetAllTestResults(); // Only for Web
 				}
 			}
 		}
 
 	}
-
-	public Object[][] scenarios() {
-		Object[][] cucumberScenarios = null;
-		try {
-			cucumberScenarios = super.scenarios();
-		} catch (Exception e) {
-			logger.error("!!!!!!!!!!!!ERROR Please check feature file if there are any lexical errors!!!");
-		}
-		return cucumberScenarios;
-	}
-
 }

--- a/test-automation-framework/src/main/java/org/iqa/test/runner/ParallelTestRunner.java
+++ b/test-automation-framework/src/main/java/org/iqa/test/runner/ParallelTestRunner.java
@@ -12,13 +12,9 @@ public class ParallelTestRunner extends BaseTest {
 	@Override
 	@DataProvider(parallel = true)
 	public Object[][] scenarios() {
-		Object[][] cucumberScenarios = null;
-		try {
-			cucumberScenarios = super.scenarios();
-		} catch (Exception e) {
-			logger.error("!!!!!!!!!!!!ERROR Please check feature file if there are any lexical errors!!!");
-		}
-		return cucumberScenarios;
+	
+		//Call to scenarios method of AbstractTestNGCucumberTests
+		return super.scenarios();
 	}
 
 }

--- a/test-automation-framework/src/main/java/org/iqa/test/runner/SequentialTestRunner.java
+++ b/test-automation-framework/src/main/java/org/iqa/test/runner/SequentialTestRunner.java
@@ -11,13 +11,9 @@ public class SequentialTestRunner extends BaseTest {
 	@Override
 	@DataProvider(parallel = false)
 	public Object[][] scenarios() {
-		Object[][] cucumberScenarios = null;
-		try {
-			cucumberScenarios = super.scenarios();
-		} catch (Exception e) {
-			logger.error("!!!!!!!!!!!!ERROR Please check feature file if there are any lexical errors!!!");
-		}
-		return cucumberScenarios;
+	
+		//Call to scenarios method of AbstractTestNGCucumberTests
+		return super.scenarios();
 	}
 
 }

--- a/test-automation-framework/src/main/java/org/iqa/test/webdriver_factory/CapabilityFactory.java
+++ b/test-automation-framework/src/main/java/org/iqa/test/webdriver_factory/CapabilityFactory.java
@@ -82,21 +82,18 @@ public class CapabilityFactory {
 			System.exit(-1);
 		}
 		logger.debug("getProperties OUT - " + propertyFileName);
-		//Adding platform to testSuiteConfigurationProperties for further usage
-		loadPlatform(properties);
+		// Loading Capabilities properties into testSuiteConfigurationProperties for
+		// further usage
+		loadPropertiesIntoTestConfig(properties);
 		return properties;
 	}
 
-	private static void loadPlatform(Properties properties) {
+	private static void loadPropertiesIntoTestConfig(Properties properties) {
 
-		if (null != properties.get("platform")) {
-			PropertyHolder.testSuiteConfigurationProperties.put("platform",
-					null != PropertyHolder.testSuiteConfigurationProperties.getProperty("platform")
-							? PropertyHolder.testSuiteConfigurationProperties.getProperty("platform")
-							: properties.get("platform"));
-		}else {
-			logger.error("!!!platform property value found null. Please add platform capability.");
-		}
+		properties.forEach((k, v) -> PropertyHolder.testSuiteConfigurationProperties.put(k.toString(),
+				null != PropertyHolder.testSuiteConfigurationProperties.getProperty(k.toString())
+						? PropertyHolder.testSuiteConfigurationProperties.getProperty(k.toString())
+						: v.toString()));
 	}
 
 }

--- a/test-automation-framework/src/main/java/org/iqa/test/webdriver_factory/CapabilityFactory.java
+++ b/test-automation-framework/src/main/java/org/iqa/test/webdriver_factory/CapabilityFactory.java
@@ -42,7 +42,7 @@ public class CapabilityFactory {
 	}
 
 	public static DesiredCapabilities getDesiredCapabilities() {
-		
+
 		if (null == desiredCapabilities) {
 			logger.error("!!!!!!!!!!!  Desired capability found null");
 		}
@@ -82,7 +82,21 @@ public class CapabilityFactory {
 			System.exit(-1);
 		}
 		logger.debug("getProperties OUT - " + propertyFileName);
+		//Adding platform to testSuiteConfigurationProperties for further usage
+		loadPlatform(properties);
 		return properties;
+	}
+
+	private static void loadPlatform(Properties properties) {
+
+		if (null != properties.get("platform")) {
+			PropertyHolder.testSuiteConfigurationProperties.put("platform",
+					null != PropertyHolder.testSuiteConfigurationProperties.getProperty("platform")
+							? PropertyHolder.testSuiteConfigurationProperties.getProperty("platform")
+							: properties.get("platform"));
+		}else {
+			logger.error("!!!platform property value found null. Please add platform capability.");
+		}
 	}
 
 }

--- a/test-automation-framework/src/main/java/org/iqa/test/webdriver_factory/CapabilityFactory.java
+++ b/test-automation-framework/src/main/java/org/iqa/test/webdriver_factory/CapabilityFactory.java
@@ -15,11 +15,11 @@ public class CapabilityFactory {
 	private static DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
 
 	static {
-		String platformOS = PropertyHolder.testSuiteConfigurationProperties.getProperty("platformOS").toString();
-		logger.debug("*********** Static block start. Platform - " + platformOS);
-		switch (platformOS) {
+		String AUT = PropertyHolder.testSuiteConfigurationProperties.getProperty("AUT").toString();
+		logger.debug("*********** Static block start. AUT - " + AUT);
+		switch (AUT) {
 		case "ANDROID":
-			logger.debug("*********** ANDROIF IN");
+			logger.debug("*********** ANDROID IN");
 			fillCapabilities(getProperties("AndroidCapabilities.properties"));
 			logger.debug("*********** ANDROIF OUT");
 			break;
@@ -35,17 +35,17 @@ public class CapabilityFactory {
 			break;
 		}
 		logger.debug("*********** Static block end");
-	}
-
-	public static DesiredCapabilities getDesiredCapabilities() {
-
-		if (null == desiredCapabilities) {
-			logger.error("!!!!!!!!!!!  Desired capability found null");
-		}
 		logger.info("********************************************************************");
 		logger.info("******************* DesiredCapabilities set as: ********************");
 		desiredCapabilities.asMap().forEach((key, value) -> logger.info(key + " - " + value));
 		logger.info("********************************************************************");
+	}
+
+	public static DesiredCapabilities getDesiredCapabilities() {
+		
+		if (null == desiredCapabilities) {
+			logger.error("!!!!!!!!!!!  Desired capability found null");
+		}
 		return desiredCapabilities;
 	}
 

--- a/test-automation-framework/src/main/java/org/iqa/test/webdriver_factory/CapabilityFactory.java
+++ b/test-automation-framework/src/main/java/org/iqa/test/webdriver_factory/CapabilityFactory.java
@@ -5,7 +5,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
-
 import org.iqa.suite.commons.PropertyHolder;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.slf4j.Logger;
@@ -13,13 +12,12 @@ import org.slf4j.LoggerFactory;
 
 public class CapabilityFactory {
 	private static final Logger logger = LoggerFactory.getLogger(CapabilityFactory.class);
-
 	private static DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
 
 	static {
-		logger.debug("*********** Static block start. Platform - "
-				+ PropertyHolder.testSuiteConfigurationProperties.getProperty("platform").toString());
-		switch (PropertyHolder.testSuiteConfigurationProperties.getProperty("platform").toString()) {
+		String platformOS = PropertyHolder.testSuiteConfigurationProperties.getProperty("platformOS").toString();
+		logger.debug("*********** Static block start. Platform - " + platformOS);
+		switch (platformOS) {
 		case "ANDROID":
 			logger.debug("*********** ANDROIF IN");
 			fillCapabilities(getProperties("AndroidCapabilities.properties"));
@@ -36,7 +34,6 @@ public class CapabilityFactory {
 			logger.debug("*********** BROWSER OUT");
 			break;
 		}
-
 		logger.debug("*********** Static block end");
 	}
 
@@ -46,7 +43,7 @@ public class CapabilityFactory {
 			logger.error("!!!!!!!!!!!  Desired capability found null");
 		}
 		logger.info("********************************************************************");
-		logger.info("*********** DesiredCapabilities being set as:                      ");
+		logger.info("******************* DesiredCapabilities set as: ********************");
 		desiredCapabilities.asMap().forEach((key, value) -> logger.info(key + " - " + value));
 		logger.info("********************************************************************");
 		return desiredCapabilities;

--- a/test-automation-framework/src/main/java/org/iqa/test/webdriver_factory/WebDriverManager.java
+++ b/test-automation-framework/src/main/java/org/iqa/test/webdriver_factory/WebDriverManager.java
@@ -2,7 +2,6 @@ package org.iqa.test.webdriver_factory;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-
 import org.iqa.suite.commons.PropertyHolder;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -12,7 +11,6 @@ import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.ios.IOSDriver;
 
@@ -21,6 +19,7 @@ public class WebDriverManager {
 
 	synchronized public static WebDriver CreateInstance() throws MalformedURLException {
 		WebDriver dr = null;
+		String platformOS = PropertyHolder.testSuiteConfigurationProperties.getProperty("platformOS").toString();
 		logger.info("********* Before Webdriver object creation");
 		try {
 			if (PropertyHolder.testSuiteConfigurationProperties.getProperty("DRIVER").toString().contains("BROWSER")) {
@@ -42,13 +41,11 @@ public class WebDriverManager {
 			} else if (PropertyHolder.testSuiteConfigurationProperties.getProperty("DRIVER").toString()
 					.contains("REMOTE")) {
 
-				if (PropertyHolder.testSuiteConfigurationProperties.getProperty("platform").toString()
-						.equalsIgnoreCase("Android"))
+				if (platformOS.equals("ANDROID"))
 					dr = new AndroidDriver<WebElement>(
 							new URL(PropertyHolder.testSuiteConfigurationProperties.getProperty("hubUrl").toString()),
 							CapabilityFactory.getDesiredCapabilities());
-				else if (PropertyHolder.testSuiteConfigurationProperties.getProperty("platform").toString()
-						.equalsIgnoreCase("iOS"))
+				else if (platformOS.equals("IOS"))
 					dr = new IOSDriver<WebElement>(
 							new URL(PropertyHolder.testSuiteConfigurationProperties.getProperty("hubUrl").toString()),
 							CapabilityFactory.getDesiredCapabilities());

--- a/test-automation-framework/src/main/java/org/iqa/test/webdriver_factory/WebDriverManager.java
+++ b/test-automation-framework/src/main/java/org/iqa/test/webdriver_factory/WebDriverManager.java
@@ -3,6 +3,7 @@ package org.iqa.test.webdriver_factory;
 import java.net.MalformedURLException;
 import java.net.URL;
 import org.iqa.suite.commons.PropertyHolder;
+import org.iqa.suite.commons.SeleniumUtils;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -19,7 +20,6 @@ public class WebDriverManager {
 
 	synchronized public static WebDriver CreateInstance() throws MalformedURLException {
 		WebDriver dr = null;
-		String platformOS = PropertyHolder.testSuiteConfigurationProperties.getProperty("platformOS").toString();
 		logger.info("********* Before Webdriver object creation");
 		try {
 			if (PropertyHolder.testSuiteConfigurationProperties.getProperty("DRIVER").toString().contains("BROWSER")) {
@@ -40,12 +40,12 @@ public class WebDriverManager {
 				}
 			} else if (PropertyHolder.testSuiteConfigurationProperties.getProperty("DRIVER").toString()
 					.contains("REMOTE")) {
-
-				if (platformOS.equals("ANDROID"))
+				String AUT = PropertyHolder.testSuiteConfigurationProperties.getProperty("AUT").toString();
+				if (AUT.equals("ANDROID"))
 					dr = new AndroidDriver<WebElement>(
 							new URL(PropertyHolder.testSuiteConfigurationProperties.getProperty("hubUrl").toString()),
 							CapabilityFactory.getDesiredCapabilities());
-				else if (platformOS.equals("IOS"))
+				else if (AUT.equals("IOS"))
 					dr = new IOSDriver<WebElement>(
 							new URL(PropertyHolder.testSuiteConfigurationProperties.getProperty("hubUrl").toString()),
 							CapabilityFactory.getDesiredCapabilities());


### PR DESCRIPTION
Issue Fixes :
-This release contains fix for Issue #55
-There was an ambiguity between "platform" property in FrameworkConfig.properties and BrowserCapabilities.properties
As a solution to this issue,
- Remove property "platform" from FrameworkConfig.properties
- Load all capabilities into testSuiteConfigurationProperties
- Update browser capabilities
- Add getOsFamilyName method to derive OS family name from platform

Code re-factoring:
- Remove redundant scenarios() method from BaseTest class
- Skip applicationToolEyeWebGetAllTestResults method